### PR TITLE
Fixes an issue where global may already be declared, and the client has trouble with rollup

### DIFF
--- a/src/listener.ts
+++ b/src/listener.ts
@@ -3,7 +3,7 @@ import EventEmitter from 'eventemitter3'
 import type {Options} from './options'
 import {MessageError, SocketError} from './errors'
 
-const global = globalThis || window
+const globalBuoy = globalThis || window
 
 export enum ListenerEncoding {
     binary = 'binary',
@@ -43,7 +43,7 @@ export class Listener extends EventEmitter {
         const baseUrl = options.service.replace(/^http/, 'ws').replace(/\/$/, '')
         this.url = `${baseUrl}/${options.channel}?v=2`
         this.encoding = options.encoding || ListenerEncoding.text
-        this.WebSocket = options.WebSocket || global.WebSocket
+        this.WebSocket = options.WebSocket || globalBuoy.WebSocket
         if (options.autoConnect !== false) {
             this.connect()
         }
@@ -70,12 +70,12 @@ export class Listener extends EventEmitter {
                 } else if (typeof event.data === 'string') {
                     this.handleMessage(new TextEncoder().encode(event.data))
                 } else if (
-                    typeof global.Buffer !== 'undefined' &&
-                    (event.data instanceof global.Buffer || Array.isArray(event.data))
+                    typeof globalBuoy.Buffer !== 'undefined' &&
+                    (event.data instanceof globalBuoy.Buffer || Array.isArray(event.data))
                 ) {
                     let buffer = event.data
-                    if (!global.Buffer.isBuffer(buffer)) {
-                        buffer = global.Buffer.concat(buffer)
+                    if (!globalBuoy.Buffer.isBuffer(buffer)) {
+                        buffer = globalBuoy.Buffer.concat(buffer)
                     }
                     this.handleMessage(
                         new Uint8Array(buffer.buffer, buffer.byteOffset, buffer.byteLength)

--- a/src/send.ts
+++ b/src/send.ts
@@ -1,6 +1,6 @@
 import type {Options} from './options'
 
-const global = globalThis || window
+const globalBuoy = globalThis || window
 
 /** Options for the [[send]] method. */
 interface SendOptions extends Options {
@@ -36,7 +36,7 @@ export type SendData = string | Uint8Array | JSONValue
  * @throws if the message can't be delivered if [[SendOptions.requireDelivery]] is set.
  */
 export async function send(message: SendData, options: SendOptions): Promise<SendResult> {
-    const fetch = options.fetch || global.fetch
+    const fetch = options.fetch || globalBuoy.fetch
     const baseUrl = options.service.replace(/^ws/, 'http').replace(/\/$/, '')
     const url = `${baseUrl}/${options.channel}`
 


### PR DESCRIPTION
Changes the global variable to globalBuoy so that it doesn't conflict with global inside of the browser.